### PR TITLE
docs: update `ddev get` to `ddev add-on get` in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,24 +23,33 @@ This can take up to 30 minutes or so due to downloading the required Docker cont
 
 ## Getting started
 
-1. In the DDEV project directory launch the command:
+1. In the DDEV project directory:
 
-```
-ddev get ddev/ddev-elasticsearch
-ddev get ssmarco/ddev-enterprise-search
-```
+    For DDEV v1.23.5 or above run
+
+    ```sh
+    ddev add-on get ddev/ddev-elasticsearch
+    ddev add-on get ssmarco/ddev-enterprise-search
+    ```
+
+    For earlier versions of DDEV run
+
+    ```sh
+    ddev get ddev/ddev-elasticsearch
+    ddev get ssmarco/ddev-enterprise-search
+    ```
 
 2. Restart the DDEV instance:
 
-```
-ddev restart
-```
+    ```sh
+    ddev restart
+    ```
 
 3. Get the URL of the Kibana dashboard (e.g. https://your-project-name.ddev.site:5602):
 
-```
-ddev describe
-```
+    ```sh
+    ddev describe
+    ```
 
 4. Login with the username `elastic` and password `elastic`.
 
@@ -52,21 +61,21 @@ ddev describe
 
 1. Update your project's `.env` file. The API keys are found in the Enterprise Search section of Kibana dashboard.
 
-```
-ENTERPRISE_SEARCH_ENGINE_PREFIX="my-index"
-ENTERPRISE_SEARCH_API_KEY="private-xxxxxxxxxxxx-change-this"
-ENTERPRISE_SEARCH_API_SEARCH_KEY="search-xxxxxxxxxxxx-change-this"
-ENTERPRISE_SEARCH_ENDPOINT="http://enterprisesearch:3002"
-```
+    ```
+    ENTERPRISE_SEARCH_ENGINE_PREFIX="my-index"
+    ENTERPRISE_SEARCH_API_KEY="private-xxxxxxxxxxxx-change-this"
+    ENTERPRISE_SEARCH_API_SEARCH_KEY="search-xxxxxxxxxxxx-change-this"
+    ENTERPRISE_SEARCH_ENDPOINT="http://enterprisesearch:3002"
+    ```
 
 2. The Enterprise Search endpoint is `http://enterprisesearch:3002`
 
 3. The following modules are tested to work out of the box in your composer.json file:
 
-```
-"silverstripe/silverstripe-search-service": "^3.0",
-"silverstripe/silverstripe-search-service-elastic": "^1.0@beta",
-```
+    ```
+    "silverstripe/silverstripe-search-service": "^3.0",
+    "silverstripe/silverstripe-search-service-elastic": "^1.0@beta",
+    ```
 
 ## Recommendations
 
@@ -113,38 +122,38 @@ This will require you to restart your ddev box `ddev restart`.
 
 1. Make sure all required containers are downloaded
 
-```
-docker pull docker.elastic.co/elasticsearch/elasticsearch:8.12.0
-docker pull docker.elastic.co/kibana/kibana:8.12.0
-docker pull docker.elastic.co/enterprise-search/enterprise-search:8.12.0
-```
+    ```sh
+    docker pull docker.elastic.co/elasticsearch/elasticsearch:8.12.0
+    docker pull docker.elastic.co/kibana/kibana:8.12.0
+    docker pull docker.elastic.co/enterprise-search/enterprise-search:8.12.0
+    ```
 
 2. Remove container volumes to restart from scratch
 
-List all existing volumes from your system:
+    List all existing volumes from your system:
 
-```
-docker volume ls
-```
+    ```sh
+    docker volume ls
+    ```
 
-This will show example output below:
+    This will show example output below:
 
-```
-DRIVER    VOLUME NAME
-local     ddev-your-project-name_elastic-certs
-local     ddev-your-project-name_elastic-data
-local     ddev-your-project-name_elastic-kibana
-local     ddev-your-project-name_enterprise-data
-```
+    ```
+    DRIVER    VOLUME NAME
+    local     ddev-your-project-name_elastic-certs
+    local     ddev-your-project-name_elastic-data
+    local     ddev-your-project-name_elastic-kibana
+    local     ddev-your-project-name_enterprise-data
+    ```
 
-Delete the volumes by running:
+    Delete the volumes by running:
 
-```
-docker volume rm ddev-your-project-name_elastic-certs \
-ddev-your-project-name_elastic-data \
-ddev-your-project-name_elastic-kibana \
-ddev-your-project-name_enterprise-data
-```
+    ```
+    docker volume rm ddev-your-project-name_elastic-certs \
+    ddev-your-project-name_elastic-data \
+    ddev-your-project-name_elastic-kibana \
+    ddev-your-project-name_enterprise-data
+    ```
 
 3. Restart by `ddev restart`
 
@@ -152,30 +161,30 @@ ddev-your-project-name_enterprise-data
 
 5. Check the logs
 
-The `elastic-config` container does the necessary prerequisites to glue together the other containers. It checks connection to Elastic Search and resets `kybana_system` password.
+    The `elastic-config` container does the necessary prerequisites to glue together the other containers. It checks connection to Elastic Search and resets `kybana_system` password.
 
-```
-ddev logs -s elastic-config
-ddev logs -s elasticsearch
-ddev logs -s kibana
-ddev logs -s enterprisesearch
-```
+    ```
+    ddev logs -s elastic-config
+    ddev logs -s elasticsearch
+    ddev logs -s kibana
+    ddev logs -s enterprisesearch
+    ```
 
 6. Check job health
 
-You might need to install `jq` for better legibility of the output.
+    You might need to install `jq` for better legibility of the output.
 
-```
-docker inspect --format "{{json .State.Health }}" ddev-your-project-name-enterprisesearch | jq
-docker inspect --format "{{json .State.Health }}" ddev-your-project-name-kibana | jq
-docker inspect --format "{{json .State.Health }}" ddev-your-project-name-elasticsearch | jq
-```
+    ```
+    docker inspect --format "{{json .State.Health }}" ddev-your-project-name-enterprisesearch | jq
+    docker inspect --format "{{json .State.Health }}" ddev-your-project-name-kibana | jq
+    docker inspect --format "{{json .State.Health }}" ddev-your-project-name-elasticsearch | jq
+    ```
 
 7. Check memory consumptions
 
-```
-docker stats
-```
+    ```
+    docker stats
+    ```
 
 
 ## Contribute


### PR DESCRIPTION
In [DDEV 1.23.5](https://github.com/ddev/ddev/releases/tag/v1.23.5) the ddev get command was deprecated in favour of ddev add-on get.

This PR updates those references in the readme file. There may be some additional markdown improvements as well.

The changes were made manually, but the PR itself was automatically created - I'm doing over 100 of these. I apologise if its not 100% to the contributor standards required by this repo. Let me know if I need to change anything.